### PR TITLE
Fixing dependencies for RHEL systems

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,13 @@ include_recipe 'build-essential'
 include_recipe 'git'
 
 # Dependencies required by nokogiri (for fog)
-%w(libxslt-dev libxml2-dev libghc-zlib-dev).each do |pkg|
+if platform_family?('debian')
+  dependencies = %w(libxslt-dev libxml2-dev libghc-zlib-dev)
+elsif platform_family?('rhel')
+  dependencies = %w(libxslt-devel libxml2-devel ghc-zlib-devel)
+end
+
+dependencies.each do |pkg|
   c_pkg = package(pkg)
   c_pkg.run_action(:install)
 end


### PR DESCRIPTION
Cookbook cannot be installed on RHEL systems (I'm using CentOS 7) due to Debian package names.