### PR TITLE
Unpin apt and build-essential dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ issues_url 'https://github.com/evertrue/et_fog-cookbook/issues' if respond_to?(:
 
 supports 'ubuntu', '= 14.04'
 
-depends 'build-essential', '~> 2.0'
-depends 'apt',             '~> 2.5'
+depends 'build-essential', '>= 2.0'
+depends 'apt',             '>= 2.5'


### PR DESCRIPTION
These are blocking us from using the [storage cookbook](https://github.com/evertrue/storage-cookbook) because we use the latest versions of the build-essential and apt cookbooks. AFAICT `et_fog` doesn't rely on anything version-specific about these dependencies; it just needs to be sure it has `build-essential` packages and an up-to-date `apt` .

Any objections? Thanks!

*Edit:* Build failure appears to be an unrelated issue with downloading rvm. I think only the repo owner can manually trigger a rebuild? Serverspecs and everything passed on my machine w/ Vagrant.