### PR TITLE
Relax version constraints for apt and build-essential

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ issues_url 'https://github.com/evertrue/et_fog-cookbook/issues' if respond_to?(:
 
 supports 'ubuntu', '= 14.04'
 
-depends 'build-essential', '~> 4.0'
-depends 'apt',             '~> 4.0'
+depends 'build-essential', '>= 4.0'
+depends 'apt',             '>= 3.0'


### PR DESCRIPTION
This was about to become unmanageable:
```
Unable to satisfy the following requirements:

- `build-essential (= 6.0.0)` required by `user-specified dependency`
- `build-essential (>= 0.0.0)` required by `ark-1.1.0`
- `build-essential (>= 0.0.0)` required by `singularity-8.1.0`
- `build-essential (>= 0.0.0)` required by `mysql2_chef_gem-1.1.0`
- `build-essential (~> 4.0)` required by `et_fog-3.0.0`
```